### PR TITLE
Managed Admin Password for DocumentDb

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,9 @@
 locals {
   enabled         = module.this.enabled
-  create_password = local.enabled && var.master_password == null && !var.manage_master_user_password
+  create_password = local.enabled && var.master_password == null && var.manage_master_user_password == null
+  // If both `var.master_password` and `var.manage_master_user_password` are set to null, the module will create a random password
+  // else if `var.master_password` is set to null - master_password is set to null as `manage_master_user_password` is set to true
+  // else `local.master_password` is set to the value provided in `var.master_password`
   master_password = local.create_password ? one(random_password.password[*].result) : var.master_password
 }
 
@@ -67,8 +70,8 @@ resource "aws_docdb_cluster" "default" {
   cluster_identifier = module.this.id
   master_username    = var.master_username
   # If `master_password` or `manage_master_user_password` is set, the other MUST be set to null, otherwise it will cause an error.
-  master_password                 = var.manage_master_user_password ? null : local.master_password
-  manage_master_user_password     = var.manage_master_user_password ? true : null
+  master_password                 = local.master_password
+  manage_master_user_password     = var.manage_master_user_password
   backup_retention_period         = var.retention_period
   preferred_backup_window         = var.preferred_backup_window
   preferred_maintenance_window    = var.preferred_maintenance_window

--- a/variables.tf
+++ b/variables.tf
@@ -99,6 +99,16 @@ variable "master_password" {
   description = "(Required unless a snapshot_identifier is provided) Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file. Please refer to the DocumentDB Naming Constraints"
 }
 
+variable "manage_master_user_password" {
+  type        = bool
+  description = "Whether to manage the master user password using AWS Secrets Manager."
+  default     = null
+  validation {
+    condition     = var.manage_master_user_password || var.manage_master_user_password == null
+    error_message = "Error: `manage_master_user_password` must be set to `true` or `null`"
+  }
+}
+
 variable "retention_period" {
   type        = number
   default     = 5
@@ -240,12 +250,3 @@ variable "allow_major_version_upgrade" {
   default     = false
 }
 
-variable "manage_master_user_password" {
-  type        = bool
-  description = <<-EOT
-  Whether to manage the master user password using AWS Secrets Manager.
-  If set to true, `master_password` will be be ignored.
-  This parameter is given priority over `master_password`.
-  EOT
-  default     = false
-}

--- a/variables.tf
+++ b/variables.tf
@@ -104,7 +104,7 @@ variable "manage_master_user_password" {
   description = "Whether to manage the master user password using AWS Secrets Manager."
   default     = null
   validation {
-    condition     = var.manage_master_user_password || var.manage_master_user_password == null
+    condition     = var.manage_master_user_password == null || var.manage_master_user_password == true
     error_message = "Error: `manage_master_user_password` must be set to `true` or `null`"
   }
 }


### PR DESCRIPTION
refactor: improve master password management logic and validation in DocumentDB cluster

## what

 - Updated `create_password` local to check for null
 - Enforced `manage_master_user_password` to be true or null (required by resource)
   - moved variable up closer to `master_password`


---

This pull request refines the handling of the `master_password` and `manage_master_user_password` variables within the Terraform module for AWS DocumentDB clusters. It introduces better logic for password management, adds validation for the new variable, and updates the module configuration accordingly.

### Password Management Updates:

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL3-R6): Updated the logic for `create_password` to account for cases where both `var.master_password` and `var.manage_master_user_password` are null. This ensures a random password is created when necessary. Additionally, simplified the handling of `master_password` and `manage_master_user_password` in the `aws_docdb_cluster` resource configuration. [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL3-R6) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL70-R74)

### Variable Refinements:

* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR102-R111): Added a new `manage_master_user_password` variable with validation to ensure it is either `true` or `null`. This replaces the previous implementation and provides clearer control over managing the master user password via AWS Secrets Manager.
* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL243-L251): Removed the old definition of `manage_master_user_password` to avoid redundancy and potential conflicts.